### PR TITLE
Replace Downloads with mailing list

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,12 @@
           <p><a class="btn" href="https://github.com/linux-test-project/ltp">View code <i class="icon-file"></i></a></p>
         </div>
         <div class="span3">
+          <h2>Mailing list</h2>
+          <p>Send patches (we prefer it over github pull-requests)
+             or discuss ideas on our mailing list.</p>
+          <p><a class="btn" href="https://lists.linux.it/listinfo/ltp">View mailing list <i class="icon-envelope"></i></a></p>
+        </div>
+        <div class="span3">
           <h2>Issues</h2>
           <p>Whether you're having trouble getting started, or the tests have
              a defect, make sure you report the problems to us.</p>
@@ -86,12 +92,6 @@
           <p>Discover how to get started, how to write new tests and how to
              contribute with LTP, using our wiki.</p>
           <p><a class="btn" href="https://github.com/linux-test-project/ltp/wiki">View documentation <i class="icon-book"></i></a></p>
-        </div>
-        <div class="span3">
-          <h2>Downloads</h2>
-          <p>Download tarballs or zipfiles straight from the version control
-             tags, so you can start working with LTP straight away.</p>
-          <p><a class="btn" href="https://github.com/linux-test-project/ltp/tags">View downloads <i class="icon-tags"></i></a></p>
         </div>
       </div>
 


### PR DESCRIPTION
One more change. If you really like old downloads, I can put it as 3rd button on the top (after `View project on github` and `Download latest tarball`). But here we can have some description. And I agree I'm a bit aggressive about pull requests :).